### PR TITLE
fix: define nodejs module

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "A discord bot that can be extended with an OpenAPI described API",
   "main": "src/main.js",
+  "type": "module",
   "scripts": {
     "build": "make build",
     "test": "make .test",


### PR DESCRIPTION
<h2>Context</h2>

Local builds were failing due to the type not being declared. This fixes that issue.

<h2>Changes</h2>

- Define type in `package.json`