### PR TITLE
fix: ci depends on build

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Context
+
+Why is this change being made
+
+## Changes
+
+- Change_1
+
+## Linked issues

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ run: build
 build: $(TS_SRC_FILES) node_modules
 	tsc --build
 
-.test: $(TS_TEST_FILES) $(TS_SRC_FILES) node_modules
+.test: $(TS_TEST_FILES) build
 	-rm .test 2> /dev/null
 	npx jest --coverage
 	touch .test


### PR DESCRIPTION
## Context

Previously the CI passes if the tests pass. There could be a case where the test passes, but the build fails. This prevents that case

## Changes

- Add build step as a dependency of the test step in CI
- Add PR template